### PR TITLE
Strict error in symfony

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -11,6 +11,8 @@
 
 namespace Tecnocreaciones\Bundle\AjaxFOSUserBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
+
 use FOS\UserBundle\Controller\ResettingController as BaseController;
 
 /**


### PR DESCRIPTION
Hello, i always get this error when i build a new cache

Strict standards: Declaration of Tecnocreaciones\Bundle\AjaxFOSUserBundle\Controller\ResettingController::sendEmailAction() should be compatible with FOS\UserBundle\Controller\ResettingController::sendEmailAction(Symfony\Component\HttpFoundation\Request $request) in C:\wamp64\www\xl\vendor\tecnocreaciones\ajax-fos-user-bundle\Tecnocreaciones\Bundle\AjaxFOSUserBundle\Controller\ResettingController.php on line 24


can you add this line : 

use Symfony\Component\HttpFoundation\Request;

at the top of ResettingController.php ?
it would avoid this error.

Thanks in advance. (i'm passing my website in Prod, hope to see the fix asap ^^; )