### PR TITLE
Fix error en RegisterController con funcion Bind en symfony 3.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -94,15 +94,14 @@ class RegistrationController extends BaseController
 
                 $form = $formFactory->createForm();
                 $form->setData($user);
+                $form->handleRequest($request);
 
                 if ('POST' === $request->getMethod()) {
-                    $form->bind($request);
-
                     if ($form->isValid()) {
                         $targetUrl = '';
                         if($this->getSession()){
                             $session = $this->getSession();
-                            if(($token = $this->container->get('security.context')->getToken()) && is_a($token, 'Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')){
+                            if(($token = $this->container->get('security.token_storage')->getToken()) && is_a($token, 'Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')){
                                 $targetUrl = $session->get('_security.' .$token->getProviderKey(). '.target_path');
                             }
                         }


### PR DESCRIPTION
Soluciona el problema del método bind en la versión de Symfony 3.0+, ya que el mismo fue eliminado en dicha versión.