### PR TITLE
Fix error in request Symfony 3.0+

### DIFF
--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 class ResettingController extends BaseController
 {
     public function sendEmailAction(Request $request) {
-        $request = $this->container->get('request');
+        
         if($request->isXmlHttpRequest()){
             $data = array();
             $response = new \Symfony\Component\HttpFoundation\JsonResponse();


### PR DESCRIPTION
En dicha commit se encuentra la solución de $request del ResettingController, pues fallaba porque en versiones anteriores se llamaba de distinta manera, se eliminó $request = $this->container->get('request'); porque ya viene inyectado en el controlador.